### PR TITLE
Add motor overheating protection and logging (#18, #19)

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,4 +46,10 @@ public final class Constants {
 	public static final int DRIVE_FWD_REV = XboxController.Axis.kLeftY.value;
     public static final int DRIVE_LEFT_RIGHT = XboxController.Axis.kRightX.value;
     public static final int REVERSE_DRIVE_DIRECTION = XboxController.Button.kStickLeft.value;
+    public static final int OVERRIDE_MOTOR_PROTECTION = XboxController.Button.kB.value;
+
+    public static final int COLOR_MOTOR_OK = 0x00FF00FF;
+    public static final int COLOR_MOTOR_WARNING = 0xFFFF00FF;
+    public static final int COLOR_MOTOR_SHUTOFF = 0xFF0000FF;
+    public static final int COLOR_MOTOR_OVERRIDDEN = 0xA72DFFFF;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,10 +7,7 @@
 
 package frc.robot;
 
-import com.arctos6135.robotlib.oi.XboxControllerButtons;
-
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.XboxController.Axis;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide
@@ -41,6 +38,8 @@ public final class Constants {
     public static final double VELOCITY_CONVERSION_FACTOR = WHEEL_CIRCUMFERENCE * GEARBOX_RATIO;
     public static final int COUNTS_PER_REVOLUTION = 42;
 
+    public static double MOTOR_WARNING_TEMP = 70;
+    public static double MOTOR_SHUTOFF_TEMP = 90;
 
     // Xbox Controller constants
 	public static final int XBOX_CONTROLLER = 0; 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -88,15 +88,15 @@ public class RobotContainer {
         driveReversedEntry = driveTab.add("Reversed", TeleopDrive.isReversed()).withWidget(BuiltInWidgets.kBooleanBox)
                 .getEntry();
         drivetrainMotorStatus = driveTab.add("DT Motor Status", true).withWidget(BuiltInWidgets.kBooleanBox)
-                .withProperties(Map.of("color when false", 0xFF000000));
+                .withProperties(Map.of("color when true", 0x00FF00FF, "color when false", 0xFF0000FF));
         drivetrain.setOverheatShutoffCallback((motor, temp) -> {
             // Make it red
-            drivetrainMotorStatus.withProperties(Map.of("color when false", 0xFF000000)).getEntry().setBoolean(false);
+            drivetrainMotorStatus.withProperties(Map.of("color when false", 0xFF0000FF)).getEntry().setBoolean(false);
             // TODO: Log this as an error and rumble
         });
         drivetrain.setOverheatWarningCallback((motor, temp) -> {
             // Make it yellow
-            drivetrainMotorStatus.withProperties(Map.of("color when false", 0xFFFF0000)).getEntry().setBoolean(false);
+            drivetrainMotorStatus.withProperties(Map.of("color when false", 0xFFFF00FF)).getEntry().setBoolean(false);
         });
         drivetrain.setNormalTempCallback(() -> {
             drivetrainMotorStatus.getEntry().setBoolean(true);

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -33,6 +33,7 @@ public class Drivetrain extends SubsystemBase {
 
     private boolean overheatShutoff = false;
     private boolean overheatWarning = false;
+    private boolean protectionOverridden = false;
     private BiConsumer<CANSparkMax, Double> overheatCallback;
     private BiConsumer<CANSparkMax, Double> overheatWarningCallback;
     private Runnable normalTempCallback;
@@ -62,12 +63,24 @@ public class Drivetrain extends SubsystemBase {
         setRightMotor(right);
     }
 
+    /**
+     * Set the percentage output of the left motor. 
+     * 
+     * @param output The motor output
+     * @see #setMotors(double, double)
+     */
     public void setLeftMotor(double output) {
-        leftMotor.set(overheatShutoff ? 0 : output * speedMultiplier);
+        leftMotor.set(overheatShutoff && !protectionOverridden ? 0 : output * speedMultiplier);
     }
 
+    /**
+     * Set the percentage output of the right motor.
+     * 
+     * @param output The motor output
+     * @see #setMotors(double, double)
+     */
     public void setRightMotor(double output) {
-        rightMotor.set(overheatShutoff ? 0 : output * speedMultiplier);
+        rightMotor.set(overheatShutoff && !protectionOverridden ? 0 : output * speedMultiplier);
     }
 
     /**
@@ -100,6 +113,36 @@ public class Drivetrain extends SubsystemBase {
      */
     public boolean isOverheatWarning() {
         return overheatWarning;
+    }
+
+    /**
+     * Set whether the overheat shutoff is overridden.
+     * 
+     * <p>
+     * When overridden, the motors will still be active even if the shutoff limit
+     * was reached. However, callbacks will still be called and the motors will
+     * still be in a "shutoff" or "warning" state.
+     * </p>
+     * 
+     * @param override Whether the overheat shutoff should be overridden
+     */
+    public void setOverheatShutoffOverride(boolean override) {
+        this.protectionOverridden = override;
+    }
+
+    /**
+     * Return whether the overheat shutoff was overridden.
+     * 
+     * <p>
+     * When overridden, the motors will still be active even if the shutoff limit
+     * was reached. However, callbacks will still be called and the motors will
+     * still be in a "shutoff" or "warning" state.
+     * </p>
+     * 
+     * @return Whether the overheat shutoff has been overridden
+     */
+    public boolean getOverheatShutoffOverride() {
+        return protectionOverridden;
     }
 
     /**
@@ -288,7 +331,7 @@ public class Drivetrain extends SubsystemBase {
             }
         }
         // Run the return to normal callback
-        if((overheatShutoff || overheatWarning) && (!shutoff && !warning) && normalTempCallback != null) {
+        if ((overheatShutoff || overheatWarning) && (!shutoff && !warning) && normalTempCallback != null) {
             normalTempCallback.run();
         }
 

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -288,7 +288,7 @@ public class Drivetrain extends SubsystemBase {
             }
         }
         // Run the return to normal callback
-        if((overheatShutoff || warning) && (!shutoff && !warning) && normalTempCallback != null) {
+        if((overheatShutoff || overheatWarning) && (!shutoff && !warning) && normalTempCallback != null) {
             normalTempCallback.run();
         }
 


### PR DESCRIPTION
Add code that monitors the temperature of the drivetrain motors and reports to Shuffleboard if they exceed a temperature limit. (#19) When exceeding 70C, a warning will be generated. When exceeding 90C, the motor will be shut off and an error will be generated. This behavior can be overridden using the B button on the controller. The logger has also been set up and will log errors and warnings from the motor protection system. (#18)