### PR TITLE
Fix drivetrain velocity conversion factor

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,10 +7,7 @@
 
 package frc.robot;
 
-import com.arctos6135.robotlib.oi.XboxControllerButtons;
-
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.XboxController.Axis;
 
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide
@@ -38,7 +35,7 @@ public final class Constants {
     public static final double WHEEL_CIRCUMFERENCE = WHEEL_DIAMETER * Math.PI;
     public static final double GEARBOX_RATIO = 1 / 10.5; // First stage 84:12 second stage 36:24
     public static final double POSITION_CONVERSION_FACTOR = WHEEL_CIRCUMFERENCE * GEARBOX_RATIO;
-    public static final double VELOCITY_CONVERSION_FACTOR = WHEEL_CIRCUMFERENCE * GEARBOX_RATIO;
+    public static final double VELOCITY_CONVERSION_FACTOR = WHEEL_CIRCUMFERENCE * GEARBOX_RATIO / 60;
     public static final int COUNTS_PER_REVOLUTION = 42;
 
 


### PR DESCRIPTION
Divide the drivetrain velocity conversion factor by 60 since by default it's in units per minute, and we want units per second.