### PR TITLE
Separate drivetrain arcade drive code from TeleopDrive and move into Drivetrain

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -98,7 +98,7 @@ public class RobotContainer {
                 }, EntryListenerFlags.kUpdate);
         // Do the same with the ramping rate
         configTab.add("Ramping Rate", TeleopDrive.getRampingRate()).withWidget(BuiltInWidgets.kNumberSlider)
-                .withProperties(Map.of("min", 0.0, "max", 3.0)).getEntry().addListener(notif -> {
+                .withProperties(Map.of("min", 0.0, "max", 1.0)).getEntry().addListener(notif -> {
                     TeleopDrive.setRampingRate(notif.value.getDouble());
                 }, EntryListenerFlags.kUpdate);
         configTab.add("Motor Warning Temp.", Constants.MOTOR_WARNING_TEMP).withWidget(BuiltInWidgets.kNumberSlider)

--- a/src/main/java/frc/robot/commands/TeleopDrive.java
+++ b/src/main/java/frc/robot/commands/TeleopDrive.java
@@ -27,7 +27,7 @@ public class TeleopDrive extends CommandBase {
 													// precisionDrive
 
 	// Ramping related
-	private static double rampingRate = 1; // Time in seconds to go from 0 to full throttle.
+	private static double rampingRate = 0.375; // Time in seconds to go from 0 to full throttle.
 
 	public TeleopDrive(Drivetrain drivetrain, GenericHID controller, int fwdRevAxis, int leftRightAxis) {
 		this.drivetrain = drivetrain;
@@ -155,7 +155,7 @@ public class TeleopDrive extends CommandBase {
 		if (Math.abs(x) <= deadband) {
 			return 0;
 		}
-		return Math.copySign(1.0 - Math.abs(x), x) / (1.0 - deadband);
+		return Math.copySign(Math.abs(x) - deadband, x) / (1.0 - deadband);
 	}
 
 	@Override

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -64,7 +64,7 @@ public class Drivetrain extends SubsystemBase {
     }
 
     /**
-     * Set the percentage output of the left motor. 
+     * Set the percentage output of the left motor.
      * 
      * @param output The motor output
      * @see #setMotors(double, double)
@@ -279,6 +279,84 @@ public class Drivetrain extends SubsystemBase {
      */
     public IdleMode getIdleMode() {
         return idleMode;
+    }
+
+    /**
+     * Drives the robot with forwards/backwards translation and rotation.
+     * 
+     * @param translation The translation ([-1.0, 1.0])
+     * @param rotation    The rotation ([-1.0, 1.0])
+     */
+    public void arcadeDriveSimple(double translation, double rotation) {
+        arcadeDriveSimple(translation, rotation, 1.0);
+    }
+
+    /**
+     * Drives the robot with forwards/backwards translation and rotation.
+     * 
+     * <p>
+     * The values will be scaled by the scaling factor before given to the motors.
+     * </p>
+     * 
+     * @param translation   The translation ([-1.0, 1.0])
+     * @param rotation      The rotation ([-1.0, 1.0])
+     * @param scalingFactor The scaling factor to multiply the output by
+     */
+    public void arcadeDriveSimple(double translation, double rotation, double scalingFactor) {
+        double l = (translation - rotation) * scalingFactor;
+        double r = (translation + rotation) * scalingFactor;
+
+        setMotors(l, r);
+    }
+
+    /**
+     * Drives the robot with forwards/backwards translation and rotation.
+     * 
+     * @param translation The translation ([-1.0, 1.0])
+     * @param rotation    The rotation ([-1.0, 1.0])
+     */
+    public void arcadeDrive(double translation, double rotation) {
+        arcadeDrive(translation, rotation, 1.0);
+    }
+
+    /**
+     * Drives the robot with forwards/backwards translation and rotation.
+     * 
+     * <p>
+     * The values will be scaled by the scaling factor before given to the motors.
+     * </p>
+     * 
+     * @param translation   The translation ([-1.0, 1.0])
+     * @param rotation      The rotation ([-1.0, 1.0])
+     * @param scalingFactor The scaling factor to multiply the output by
+     */
+    public void arcadeDrive(double translation, double rotation, double scalingFactor) {
+        // Copied from edu.wpi.first.wpilibj.drive.DifferentialDrive.arcadeDrive(double,
+        // double, boolean)
+        double l, r;
+        double maxInput = Math.copySign(Math.max(Math.abs(translation), Math.abs(rotation)), translation);
+
+        if (translation >= 0.0) {
+            // First quadrant, else second quadrant
+            if (rotation >= 0.0) {
+                l = maxInput;
+                r = translation - rotation;
+            } else {
+                l = translation + rotation;
+                r = maxInput;
+            }
+        } else {
+            // Third quadrant, else fourth quadrant
+            if (rotation >= 0.0) {
+                l = translation + rotation;
+                r = maxInput;
+            } else {
+                l = maxInput;
+                r = translation - rotation;
+            }
+        }
+
+        setMotors(l, r);
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -287,34 +287,6 @@ public class Drivetrain extends SubsystemBase {
      * @param translation The translation ([-1.0, 1.0])
      * @param rotation    The rotation ([-1.0, 1.0])
      */
-    public void arcadeDriveSimple(double translation, double rotation) {
-        arcadeDriveSimple(translation, rotation, 1.0);
-    }
-
-    /**
-     * Drives the robot with forwards/backwards translation and rotation.
-     * 
-     * <p>
-     * The values will be scaled by the scaling factor before given to the motors.
-     * </p>
-     * 
-     * @param translation   The translation ([-1.0, 1.0])
-     * @param rotation      The rotation ([-1.0, 1.0])
-     * @param scalingFactor The scaling factor to multiply the output by
-     */
-    public void arcadeDriveSimple(double translation, double rotation, double scalingFactor) {
-        double l = (translation - rotation) * scalingFactor;
-        double r = (translation + rotation) * scalingFactor;
-
-        setMotors(l, r);
-    }
-
-    /**
-     * Drives the robot with forwards/backwards translation and rotation.
-     * 
-     * @param translation The translation ([-1.0, 1.0])
-     * @param rotation    The rotation ([-1.0, 1.0])
-     */
     public void arcadeDrive(double translation, double rotation) {
         arcadeDrive(translation, rotation, 1.0);
     }
@@ -323,7 +295,8 @@ public class Drivetrain extends SubsystemBase {
      * Drives the robot with forwards/backwards translation and rotation.
      * 
      * <p>
-     * The values will be scaled by the scaling factor before given to the motors.
+     * The values will be scaled by the scaling factor before given to the motors. A
+     * negative rotation value rotates the robot counterclockwise.
      * </p>
      * 
      * @param translation   The translation ([-1.0, 1.0])
@@ -331,30 +304,8 @@ public class Drivetrain extends SubsystemBase {
      * @param scalingFactor The scaling factor to multiply the output by
      */
     public void arcadeDrive(double translation, double rotation, double scalingFactor) {
-        // Copied from edu.wpi.first.wpilibj.drive.DifferentialDrive.arcadeDrive(double,
-        // double, boolean)
-        double l, r;
-        double maxInput = Math.copySign(Math.max(Math.abs(translation), Math.abs(rotation)), translation);
-
-        if (translation >= 0.0) {
-            // First quadrant, else second quadrant
-            if (rotation >= 0.0) {
-                l = maxInput;
-                r = translation - rotation;
-            } else {
-                l = translation + rotation;
-                r = maxInput;
-            }
-        } else {
-            // Third quadrant, else fourth quadrant
-            if (rotation >= 0.0) {
-                l = translation + rotation;
-                r = maxInput;
-            } else {
-                l = maxInput;
-                r = translation - rotation;
-            }
-        }
+        double l = (translation + rotation) * scalingFactor;
+        double r = (translation - rotation) * scalingFactor;
 
         setMotors(l, r);
     }
@@ -378,6 +329,7 @@ public class Drivetrain extends SubsystemBase {
         // According to the docs, setInverted() has no effect if motor is a follower
         // Therefore only the master needs to be inverted
         leftMotor.setInverted(true);
+        rightMotor.setInverted(false);
 
         leftEncoder.setPositionConversionFactor(Constants.POSITION_CONVERSION_FACTOR);
         rightEncoder.setPositionConversionFactor(Constants.POSITION_CONVERSION_FACTOR);


### PR DESCRIPTION
Partially separate the code doing the conversion from joystick input to motor output for arcade drive in `TeleopDrive`, and move into `Drivetrain` as `arcadeDrive(double, double, double)` or `arcadeDrive(double, double)`. This makes writing autos in the future more convenient. 

Fix a bug with the direction of the motors on the right side of the drivetrain being reversed sometimes, causing confusion in the driving direction. 